### PR TITLE
CMake: allow optional ROOT libraries and more conventional installation with instructions in the README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,10 @@ endforeach()
 
 # Configure install destination
 install(TARGETS cropsimpletools ${EXELIST}
-  RUNTIME DESTINATION ${SMPT_SOURCE_DIR}/bin
-  LIBRARY DESTINATION ${SMPT_SOURCE_DIR}/lib
-  ARCHIVE DESTINATION ${SMPT_SOURCE_DIR}/lib/static)
+  RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+  LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/static)
+
+# Provide easy (but dumb) way to uninstall
+add_custom_target(uninstall xargs rm -v < install_manifest.txt)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,10 @@ endforeach()
 # Locate Boost
 find_package(Boost REQUIRED system)
 
-#Check the compiler and set the compile and link flags
-set(CMAKE_BUILD_TYPE Debug)
-
+# Check the compiler and set the compile and link flags
+#set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY lib)
-
 
 include_directories(${ROOT_INCLUDE_DIRS} ${SMPT_SOURCE_DIR}/include)
 
@@ -43,7 +41,7 @@ ${SMPT_SOURCE_DIR}/src/cropcutensemble.cc
 ${SMPT_SOURCE_DIR}/src/cropdatastore.cc
 )
 
-
+# List executables and link each of them to the local and ROOT libraries
 set(EXELIST thresholdeffs bwdiv crop stackergen rangefinder sepper mergevars updatedatastore stacker varstocuts eff corr cuttester columnmaker multicolumnmaker tuplesampler tuplescrambler cutapplier)
 
 foreach(exe ${EXELIST})
@@ -51,8 +49,9 @@ foreach(exe ${EXELIST})
   target_link_libraries (${exe} cropsimpletools ${ROOT_LIBRARIES})
 endforeach()
 
-
+# Configure install destination
 install(TARGETS cropsimpletools ${EXELIST}
   RUNTIME DESTINATION ${SMPT_SOURCE_DIR}/bin
   LIBRARY DESTINATION ${SMPT_SOURCE_DIR}/lib
   ARCHIVE DESTINATION ${SMPT_SOURCE_DIR}/lib/static)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ foreach(opt ${ROOT_OPTIONAL_COMPONENTS})
   endif()
 endforeach()
 
+# Locate Boost
+find_package(Boost REQUIRED system)
+
 #Check the compiler and set the compile and link flags
 set(CMAKE_BUILD_TYPE Debug)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,20 @@ endif()
 
 project(SMPT)
 
-#set(CMAKE_CXX_FLAGS "-std=c++11")
-
 # Load Macro to locate ROOT and needed libraries
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
-find_package(ROOT REQUIRED Core RIO Net Hist Graf Graf3d Gpad Tree Rint
+set(ROOT_REQUIRED_COMPONENTS Core RIO Net Hist Graf Graf3d Gpad Tree Rint
 Postscript Matrix Physics MathCore Thread Gui TreePlayer Minuit TMVA)
+#set(ROOT_OPTIONAL_COMPONENTS Proof)
+find_package(ROOT REQUIRED ${ROOT_REQUIRED_COMPONENTS}
+OPTIONAL_COMPONENTS ${ROOT_OPTIONAL_COMPONENTS})
+
+# Set preprocessor flags for optional components
+foreach(opt ${ROOT_OPTIONAL_COMPONENTS})
+  if(ROOT_${opt}_LIBRARY)
+    add_definitions(-Duse_${opt})
+  endif()
+endforeach()
 
 #Check the compiler and set the compile and link flags
 set(CMAKE_BUILD_TYPE Debug)
@@ -37,7 +45,7 @@ set(EXELIST thresholdeffs bwdiv crop stackergen rangefinder sepper mergevars upd
 
 foreach(exe ${EXELIST})
   add_executable(${exe} ${SMPT_SOURCE_DIR}/src/${exe}.cc)
-  target_link_libraries (${exe} cropsimpletools ${ROOT_LIBRARIES}) 
+  target_link_libraries (${exe} cropsimpletools ${ROOT_LIBRARIES})
 endforeach()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ foreach(opt ${ROOT_OPTIONAL_COMPONENTS})
   endif()
 endforeach()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ROOT_CXX_FLAGS}")
+
 # Locate Boost
 find_package(Boost REQUIRED system)
 

--- a/README.md
+++ b/README.md
@@ -13,3 +13,28 @@ The most recent version of simpletools, including the above documentation will a
 
 Bug reports, feature requests, comments and patches are always welcome.  \
 conor.fitzpatrick@cern.ch
+
+## Installation
+
+Building and installing are done with CMake.
+If you want to install simpletools system-wide, run:
+
+    cmake .
+    make
+    sudo make install
+
+If you don't have administrator privileges and/or want to install locally, use `-DCMAKE_INSTALL_PREFIX` to change the destination, *e.g.*:
+
+    cmake . -DCMAKE_INSTALL_PREFIX=~/.local/
+    make
+    make install
+
+### Uninstallation
+
+After running `make install`, a file called `install_manifest.txt` will be created, which lists the destinations of all installed binaries and libraries.
+To uninstall, you can run:
+
+    make uninstall
+
+which will delete every file listed in `install_manifest.txt`.
+


### PR DESCRIPTION
I copied the [latest version of `FindROOT.cmake`](https://github.com/root-project/root/blob/master/etc/cmake/FindROOT.cmake) from the ROOT git repo. This interprets `OPTIONAL_COMPONENTS`.

In `CMakeLists.txt` you can now specify optional ROOT libraries, and each one will define a preprocessor variable `use_${lib}`

e.g. in `CMakeLists.txt`:
```cmake
set(ROOT_OPTIONAL_COMPONENTS Proof)
```
in some C++ source file:
```c++
#ifdef use_Proof
#include <TProof.h>
#endif
```